### PR TITLE
Save IP address configuration when rebooting

### DIFF
--- a/scripts/start-stop-status
+++ b/scripts/start-stop-status
@@ -1,14 +1,53 @@
 #!/bin/sh
 # Copyright (C) 2000-2017 Synology Inc. All rights reserved.
 
+set_interfaces()
+{
+  action=$1
+  driver_name="aqc111"
+  for interface_name in $(ls /sys/class/net)
+  do
+    # Skip loopback interface, since it doesn have a device/driver
+    # folder.
+      if [ "$interface_name" = "lo" ]
+      then
+        continue
+      fi
+      # For all other interfaces list the device driver folder and
+      # bring interface up/down if the device driver folder links to
+      # something with aqc111 in its name.
+      driver_location=$(ls -ld /sys/class/net/$interface_name/device/driver)
+      interface_has_aqc111_driver=false
+      if [ ! -z "$(echo "$driver_location" | grep $driver_name)" ]
+      then
+        interface_has_aqc111_driver=true
+      fi
+      if [ $interface_has_aqc111_driver = true ]
+      then
+        config_file=/etc/sysconfig/network-scripts/ifcfg-$interface_name
+        config_storage_location=$SYNOPKG_PKGDEST/ifcfg-$interface_name
+        if [ -f "$config_file" ] && [ "$action" = "down" ]
+        then
+          cp $config_file $config_storage_location
+        elif [ "$action" = "up" ] && [ -f "$config_storage_location" ]
+        then
+          cp $config_storage_location $config_file
+        fi
+        ifconfig $interface_name $action
+      fi
+  done
+}
+
 case $1 in
 	start)
 		/sbin/insmod $SYNOPKG_PKGDEST/aqc111/mii.ko
 		/sbin/insmod $SYNOPKG_PKGDEST/aqc111/usbnet.ko
 		/sbin/insmod $SYNOPKG_PKGDEST/aqc111/aqc111.ko
+		set_interfaces up
 		exit 0
 	;;
 	stop)
+		set_interfaces down
 		/sbin/rmmod $SYNOPKG_PKGDEST/aqc111/aqc111.ko
 		/sbin/rmmod $SYNOPKG_PKGDEST/aqc111/usbnet.ko
 		/sbin/rmmod $SYNOPKG_PKGDEST/aqc111/mii.ko


### PR DESCRIPTION
The original developer [bb-qq](https://github.com/bb-qq/aqc111) asked for a solution to save IP address configuration:

> IP address configuration will be lost after the device is rebooted. If you find a solution for this issue, please share it.

I also don't have a clue why the configuration gets overwritten with an empty one; so I decided to probe for interfaces that seem to use the aqc111 driver and save/restore the configuration according to starting/stopping the aqc111 package service respectively. This should persist the config in between reboots.
Install the package as described in the `readme.md` and instead of using `ifconfig <interface name> up`, please use `sudo synoservice --start pkgctl-aqc111` to bring up the interface. Use the DSM GUI to configure the interface and reboot your device to test whether your configuration was actually saved. I've tested it with my Synology DS416play NAS combined with the [QNAP QNA-UC5G1T](https://www.qnap.com/en/product/qna-uc5g1t) USB-Ethernet dongle.

It's also possible to change an already installed driver by editing `/var/packages/aqc111/scripts/start-stop-status`.